### PR TITLE
Added power support for the travis.yml file with ppc64le.  excluded  GO version 1.2,1.3 &1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 arch:
-  - amd64
-  - ppc64le
+ - amd64
+ - ppc64le
 go:
   - tip
   - 1.8
@@ -14,13 +14,10 @@ go:
   # Disable GO version 1.2,1.3 &1.4
 jobs:
   exclude:
-    - arch: amd64
     - arch: ppc64le
       go: 1.2
-    - arch: amd64
     - arch: ppc64le
       go: 1.3
-    - arch: amd64
     - arch: ppc64le
       go: 1.4
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,16 @@ go:
   - 1.4
   - 1.3
   - 1.2
+  # Disable GO version 1.2,1.3 &1.4
+jobs:
+  exclude:
+    - arch: amd64
+    - arch: ppc64le
+      go: 1.2
+    - arch: ppc64le
+      go: 1.3
+    - arch: ppc64le
+      go: 1.4
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ go:
   # Disable GO version 1.2,1.3 &1.4
 jobs:
   exclude:
+    - arch: amd64
+      go: 1.2
     - arch: ppc64le
       go: 1.2
     - arch: ppc64le

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+arch:
+  - amd64
+  - ppc64le
 go:
   - tip
   - 1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ jobs:
     - arch: amd64
     - arch: ppc64le
       go: 1.2
+    - arch: amd64
     - arch: ppc64le
       go: 1.3
+    - arch: amd64
     - arch: ppc64le
       go: 1.4
 notifications:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.

# Disable GO version 1.2,1.3 &1.4
jobs:
  exclude:
    - arch: amd64
      go: 1.2
    - arch: ppc64le
      go: 1.2
    - arch: ppc64le
      go: 1.3
    - arch: ppc64le
      go: 1.4